### PR TITLE
Hotkey for showing margins and distances

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -97,6 +97,6 @@ This property is especially handy for tabs.
 
 ## Margins and Distances
 
-Lunacy shows margins, as well as distances between elements.
+Lunacy shows margins as well as distances between elements with the command Distances from Objects (hotkey `Alt`).
 
 ![Measure margins and distances between elements](public/mAz4bmww76HilrhUizdqvw_img_49.png)


### PR DESCRIPTION
Being more explicit about how to show margins and distances, which is something that stumped me for a while when I was reading the documentation for the first time.